### PR TITLE
Add support for DK presences

### DIFF
--- a/modules/DeathKnight.lua
+++ b/modules/DeathKnight.lua
@@ -2,6 +2,9 @@
 local myname, Cork = ...
 if Cork.MYCLASS ~= "DEATHKNIGHT" then return end
 
+-- Presence
+Cork:GenerateAdvancedSelfBuffer("Presence", {48263,48266,48265})
+
 
 -- Bone Shield
 local spellname, _, icon = GetSpellInfo(49222)


### PR DESCRIPTION
Added support for DK presences (advanced auto self buffer based on Paladin auras)

Tested without issues on an 85 Blood/Frost DK.  I can't imagine why it would have issues with chars who don't have access to Blood or Unholy presence, as DKs have frost presence upon creation.
