### PR TITLE
Fix nil error

### DIFF
--- a/templates/SelfBuffer.lua
+++ b/templates/SelfBuffer.lua
@@ -12,7 +12,7 @@ end
 
 local function CheckCooldown(self)
 	local start, duration = GetSpellCooldown(self.spellname)
-	if start == 0 then return true end
+	if not start or start == 0 then return true end
 
 	Cork.StartTimer(start + duration, self.Scan)
 	return false


### PR DESCRIPTION
This fixes an error I had recently where GetSpellCooldown returns nil upon login.

Message: ..\AddOns\Cork\templates\SelfBuffer.lua line 17:
   attempt to perform arithmetic on local 'start' (a nil value)
Debug:
   (tail call): ?
   (tail call): ?
   Cork\templates\SelfBuffer.lua:17:
      Cork\templates\SelfBuffer.lua:13
   Cork\templates\SelfBuffer.lua:27: TestWithoutResting()
   Cork\modules\DarkmoonExp.lua:36: Test()
   Cork\templates\SelfBuffer.lua:65: Scan()
   Cork\Cork.lua:42:
      Cork\Cork.lua:37
   [string "safecall Dispatcher[1]"]:4:
      [string "safecall Dispatcher[1]"]:4

   [string "safecall Dispatcher[1]"]:13: ?()
   ...ore\libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:90: Fire()
   ...\AddOns\DataStore\libs\AceEvent-3.0\AceEvent-3.0.lua:120:
      ...\AddOns\DataStore\libs\AceEvent-3.0\AceEvent-3.0.lua:119
