### PR TITLE
SelfBufferAdvanced: spells can be unlearned.

### DIFF
--- a/templates/SelfBufferAdvanced.lua
+++ b/templates/SelfBufferAdvanced.lua
@@ -22,7 +22,7 @@ function Cork:GenerateAdvancedSelfBuffer(modulename, spellidlist, combatonly, us
 	})
 
 	local function RefreshKnownSpells() -- Refresh in case the player has learned this since login
-		for buff in pairs(icons) do if known[buff] == nil then known[buff] = GetSpellInfo(buff) end end
+		for buff in pairs(icons) do known[buff] = GetSpellInfo(buff) end
 	end
 
 	function dataobj:Init()


### PR DESCRIPTION
Talents and glyphs might cause spells to be unlearned, so the configuration should updated accordingly.
