### PR TITLE
Some updates for WoW 8.0

### DIFF
--- a/Cork.lua
+++ b/Cork.lua
@@ -291,6 +291,10 @@ end)
 --      Shared functions      --
 --------------------------------
 
+function Cork.UnitAura(unit, spellname, filter)
+	return AuraUtil.FindAuraByName(spellname, unit, filter)
+end
+
 function Cork.IsSpellInRange(spell, unit)
 	return IsSpellInRange(spell, unit) == 1
 end

--- a/Cork.toc
+++ b/Cork.toc
@@ -1,4 +1,4 @@
-## Interface: 70100
+## Interface: 80000
 
 ## Title: Cork
 ## Notes: Buff reminders and more

--- a/modules/BonusEvents.lua
+++ b/modules/BonusEvents.lua
@@ -10,7 +10,7 @@ local WQ_ICONLINE = ns.IconLine(WQ_BUFF_ICON, "Bonus event quest")
 -- You have to be 110 to get the weekly bonus events
 if UnitLevel("player") < 110 then return end
 
-
+local UnitAura = ns.UnitAura or UnitAura
 local ldb, ae = LibStub:GetLibrary("LibDataBroker-1.1"), LibStub("AceEvent-3.0")
 
 

--- a/modules/DarkmoonExp.lua
+++ b/modules/DarkmoonExp.lua
@@ -23,7 +23,7 @@ end
 
 
 function dataobj:Init()
-	if UnitLevel("player") < maxlevel then OpenCalendar() end
+	if UnitLevel("player") < maxlevel then C_Calendar.OpenCalendar() end
 end
 
 

--- a/modules/DarkmoonExp.lua
+++ b/modules/DarkmoonExp.lua
@@ -10,9 +10,22 @@ local hatspell = GetSpellInfo(136583)
 local dataobj = ns:GenerateSelfBuffer(itemname, icon, spellname, hatspell)
 ns.defaultspc[itemname.."-enabled"] = true
 
+local localizedNames = {
+	["deDE"] = "Dunkelmond-Jahrmarkt",
+	["esES"] = "Feria de la Luna Negra",
+	["esMX"] = "Feria de la Luna Negra",
+	["frFR"] = "Foire de Sombrelune",
+	["itIT"] = "Fiera di Lunacupa",
+	["koKR"] = "다크문 축제",
+	["ptBR"] = "Feira de Negraluna",
+	["ruRU"] = "Ярмарка Новолуния",
+	["zhCN"] = "暗月马戏团",
+	["zhTW"] = "暗月马戏团",
+}
+local holidayName = localizedNames[GetLocale()] or "Darkmoon Faire"
 
 local function DarkmoonToday()
-	return ns.IsHolidayActive("Darkmoon Faire")
+	return ns.IsHolidayActive(holidayName)
 end
 
 

--- a/modules/GarrisonBodyguardMinifier.lua
+++ b/modules/GarrisonBodyguardMinifier.lua
@@ -38,16 +38,15 @@ end
 
 
 local zoneids = {}
-local function ParseSubzones(id, name, ...)
-	zoneids[name] = true
-	if select("#", ...) > 0 then return ParseSubzones(...) end
+-- Get all Draenor (sub)zones where we might use the follower.
+local zones = C_Map.GetMapChildrenInfo(572, Enum.UIMapType.Zone, true)
+for _, zone in ipairs(zones) do
+	zoneids[zone.name] = true
+	local subzones = C_Map.GetMapChildrenInfo(zone.mapID, Enum.UIMapType.Micro, true)
+	for _, subzone in ipairs(subzones) do
+		zoneids[subzone.name] = true
+	end
 end
-local function ParseZones(id, name, ...)
-	zoneids[name] = true
-	ParseSubzones(GetMapSubzones(id))
-	if select("#", ...) > 0 then return ParseZones(...) end
-end
-ParseZones(GetMapZones(7))
 
 
 local orig2 = dataobj.TestWithoutResting

--- a/modules/Paladin.lua
+++ b/modules/Paladin.lua
@@ -1,6 +1,7 @@
 
 local myname, Cork = ...
 if Cork.MYCLASS ~= "PALADIN" then return end
+local UnitAura = Cork.UnitAura or UnitAura
 local ldb, ae = LibStub:GetLibrary("LibDataBroker-1.1"), LibStub("AceEvent-3.0")
 
 -- Righteous Fury
@@ -30,7 +31,7 @@ function dataobj:Test(unit)
     or (not raidunits[unit] and not partyunits[unit] and not otherunits[unit]) then return 0 end
   local count = 0
   for _, spellname in ipairs(spellnames) do
-    if UnitAura(unit, spellname, nil, "PLAYER") then
+    if UnitAura(unit, spellname, "PLAYER") then
       count = count + 1
     end
   end
@@ -66,12 +67,12 @@ function dataobj:CorkIt(frame)
     -- prioritize the first spell based on our role
     local role = GetSpecializationRole(GetSpecialization())
     local rolespell = rolespells[role]
-    if role and not UnitAura("player", spellnames[rolespell], nil, "PLAYER") then -- should this be player-only?
+    if role and not UnitAura("player", spellnames[rolespell], "PLAYER") then -- should this be player-only?
       return frame:SetManyAttributes("type1", "spell", "spell", spellnames[rolespell], "unit", "player")
     end
     -- otherwise just do the spells in order
     for _, spellname in ipairs(spellnames) do
-      if not UnitAura("player", spellname, nil, "PLAYER") then -- should this be player-only?
+      if not UnitAura("player", spellname, "PLAYER") then -- should this be player-only?
         return frame:SetManyAttributes("type1", "spell", "spell", spellname, "unit", "player")
       end
     end

--- a/modules/PaladinSeal.lua
+++ b/modules/PaladinSeal.lua
@@ -4,7 +4,7 @@ if Cork.MYCLASS ~= "PALADIN" then return end
 
 
 local myname, Cork = ...
-local UnitAura = UnitAura
+local UnitAura = Cork.UnitAura or UnitAura
 local SpellCastableOnUnit = Cork.SpellCastableOnUnit
 local ldb, ae = LibStub:GetLibrary("LibDataBroker-1.1"), LibStub("AceEvent-3.0")
 

--- a/modules/PilgrimsBountyRep.lua
+++ b/modules/PilgrimsBountyRep.lua
@@ -22,7 +22,7 @@ end
 
 
 function dataobj:Init()
-	if UnitLevel("player") == maxlevel then OpenCalendar() end
+	if UnitLevel("player") == maxlevel then C_Calendar.OpenCalendar() end
 end
 
 

--- a/modules/PilgrimsBountyRep.lua
+++ b/modules/PilgrimsBountyRep.lua
@@ -9,9 +9,22 @@ local spellname, _, icon = GetSpellInfo(61849)
 local dataobj = ns:GenerateSelfBuffer(itemname, icon, spellname)
 ns.defaultspc[itemname.."-enabled"] = true
 
+local localizedNames = {
+	["deDE"] = "Pilgerfreudenfest",
+	["esES"] = "Generosidad del Peregrino",
+	["esMX"] = "Generosidad del Peregrino",
+	["frFR"] = "Les Bienfaits du pèlerin",
+	["itIT"] = "Ringraziamento del Pellegrino",
+	["koKR"] = "순례자의 감사절",
+	["ptBR"] = "Festa da Fartura",
+	["ruRU"] = "Пиршество странников",
+	["zhCN"] = "感恩节",
+	["zhTW"] = "感恩节",
+}
+local holidayName = localizedNames[GetLocale()] or "Pilgrim's Bounty"
 
 local function BountyToday()
-	return ns.IsHolidayActive("Pilgrim's Bounty")
+	return ns.IsHolidayActive(holidayName)
 end
 
 

--- a/modules/WarlockSoulLink.lua
+++ b/modules/WarlockSoulLink.lua
@@ -3,7 +3,7 @@ local myname, Cork = ...
 if Cork.MYCLASS ~= "WARLOCK" then return end
 
 local myname, Cork = ...
-local UnitAura = UnitAura
+local UnitAura = Cork.UnitAura or UnitAura
 local ldb, ae = LibStub:GetLibrary("LibDataBroker-1.1"), LibStub("AceEvent-3.0")
 
 

--- a/modules/WellFed.lua
+++ b/modules/WellFed.lua
@@ -1,6 +1,6 @@
 
 local myname, Cork = ...
-local UnitAura = UnitAura
+local UnitAura = Cork.UnitAura or UnitAura
 local ldb, ae = LibStub:GetLibrary("LibDataBroker-1.1"), LibStub("AceEvent-3.0")
 
 

--- a/services/holiday_active.lua
+++ b/services/holiday_active.lua
@@ -3,11 +3,11 @@ local myname, ns = ...
 
 
 function ns.IsHolidayActive(name)
-	local _, _, day = CalendarGetDate()
+	local day = C_Calendar.GetDate().monthDay
 	local title, hour, sequenceType
 	local i = 1
 	repeat
-		title, hour, _, _, sequenceType = CalendarGetDayEvent(0, day, i)
+		title, hour, _, _, sequenceType = C_Calendar.GetDayEvent(0, day, i)
 		if title == name then
 			if sequenceType == "START" then
 				return GetGameTime() >= hour


### PR DESCRIPTION
Due to the many uses of `UnitAura` throughout the modules, I continued with the `local UnitAura = ns.UnitAura or UnitAura` pattern and added the `Cork.UnitAura` function as a workaround to the changes to `UnitAura`. This should probably be changed in all occurences, but for now this should do ;)